### PR TITLE
Create .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.gradle
+build/
+*.log
+*.tmp
+
+.idea/
+*.iml
+*.swp


### PR DESCRIPTION
.dockerignore to exclude unnecessary files from Docker build context.